### PR TITLE
Update metagraph-cogdl plugin to pass round-tripper tests

### DIFF
--- a/metagraph_cogdl/plugins/cogdl/algorithms.py
+++ b/metagraph_cogdl/plugins/cogdl/algorithms.py
@@ -9,24 +9,23 @@ if has_cogdl:
     import networkx as nx
     from metagraph.plugins.networkx.types import NetworkXGraph
     from metagraph.plugins.numpy.types import (
-        NumpyMatrix,
+        NumpyMatrixType,
         NumpyNodeMap,
     )
 
     @concrete_algorithm("embedding.train.hope.katz")
     def cogdl_hope_katz_train(
         graph: NetworkXGraph, embedding_size: int, beta: float
-    ) -> Tuple[NumpyMatrix, NumpyNodeMap]:
+    ) -> Tuple[NumpyMatrixType, NumpyNodeMap]:
         model = cogdl.models.emb.hope.HOPE(embedding_size, beta)
         np_embedding_matrix = model.train(
             graph.value
         )  # performs NetworkX -> SciPy adjacency matrix underneath
-        matrix = NumpyMatrix(np_embedding_matrix)
         node2index = NumpyNodeMap(
             np.arange(len(graph.value.nodes())),
-            node_ids=dict(map(reversed, enumerate(sorted(graph.value.nodes())))),
+            nodes=np.array(list(graph.value.nodes())),
         )
-        return (matrix, node2index)
+        return (np_embedding_matrix, node2index)
 
     @concrete_algorithm("embedding.train.line")
     def cog_dl_line_train(
@@ -37,7 +36,7 @@ if has_cogdl:
         epochs: int,
         learning_rate: float,
         batch_size: int,
-    ) -> Tuple[NumpyMatrix, NumpyNodeMap]:
+    ) -> Tuple[NumpyMatrixType, NumpyNodeMap]:
         # walk_length is a poorly named parameter ; in the underlying code, we have
         # num_total_training_examples = walk_length * walks_per_node * len(graph.value.nodes)
         # Thus, walk_length can be used to specify the number of epochs
@@ -51,9 +50,8 @@ if has_cogdl:
             order=3,
         )
         np_embedding_matrix = model.train(graph.value)
-        matrix = NumpyMatrix(np_embedding_matrix)
         node2index = NumpyNodeMap(
             np.arange(len(graph.value.nodes())),
-            node_ids=dict(map(reversed, enumerate(sorted(graph.value.nodes())))),
+            nodes=np.array(list(graph.value.nodes())),
         )
-        return (matrix, node2index)
+        return (np_embedding_matrix, node2index)


### PR DESCRIPTION
This commit makes the `metagraph-cogdl` plugin pass the round-tripper tests.